### PR TITLE
Update coverage-badge to handle multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ CoverageBadge is a library for creating an SVG coverage badge from a Clover XML 
 
 ## Installation
 
-Composer!
+Composer
+
+`composer require codebtech/coveragebadge --dev`
 
 
 ## Usage

--- a/coverage-badge.php
+++ b/coverage-badge.php
@@ -1,54 +1,59 @@
 <?php
 
-$inputFile  = $argv[1];
+$inputFiles  = explode(',', $argv[1]);
 $outputFile = $argv[2];
 $coverageName = isset($argv[3]) ? $argv[3] : 'coverage';
 
-if (!file_exists($inputFile)) {
-    throw new InvalidArgumentException('Invalid input file provided');
-}
+$totalCoverage = 0;
+$totalElements = 0;
+$checkedElements = 0;
 
-try {
-    $xml = new SimpleXMLElement(file_get_contents($inputFile));
-
-    $metrics         = $xml->xpath('//metrics');
-    $totalElements   = 0;
-    $checkedElements = 0;
-
-    foreach ($metrics as $metric) {
-        $totalElements   += (int) $metric['elements'];
-        $checkedElements += (int) $metric['coveredelements'];
+foreach ($inputFiles as $inputFile) {
+    if (!file_exists($inputFile)) {
+        throw new InvalidArgumentException('Invalid input file provided: ' . $inputFile);
     }
 
-    $coverage = (int)(($totalElements === 0) ? 0 : ($checkedElements / $totalElements) * 100);
+    try {
+        $xml = new SimpleXMLElement(file_get_contents($inputFile));
 
-    $template = file_get_contents(__DIR__ . '/templates/badge.svg');
+        $metrics = $xml->xpath('//metrics');
 
-    $template = str_replace('{{ total }}', $coverage, $template);
+        foreach ($metrics as $metric) {
+            $totalElements   += (int) $metric['elements'];
+            $checkedElements += (int) $metric['coveredelements'];
+        }
 
-    $template = str_replace('{{ coverage }}', $coverageName, $template);
-
-    $color = '#a4a61d';      // Default Gray
-    if ($coverage < 40) {
-        $color = '#e05d44';  // Red
-    } elseif($coverage < 60) {
-        $color = '#fe7d37';  // Orange
-    } elseif($coverage < 75) {
-        $color = '#dfb317';  // Yellow
-    } elseif($coverage < 90) {
-        $color = '#a4a61d';  // Yellow-Green
-    } elseif($coverage < 95) {
-        $color = '#97CA00';  // Green
-    } elseif ($coverage <= 100) {
-        $color = '#4c1';     // Bright Green
+        $coverage = round(($totalElements === 0) ? 0 : ($checkedElements / $totalElements) * 100);
+        $totalCoverage += $coverage;
+    } catch (Exception $e) {
+        echo $e->getMessage();
     }
-
-    $template = str_replace('{{ total }}', $coverage, $template);
-    $template = str_replace('{{ color }}', $color, $template);
-
-    file_put_contents($outputFile, $template);
-} catch (Exception $e) {
-    echo $e->getMessage();
 }
 
+$totalCoverage = $totalCoverage / count($inputFiles); // Average coverage across all files
 
+$template = file_get_contents(__DIR__ . '/templates/badge.svg');
+
+$template = str_replace('{{ total }}', $totalCoverage, $template);
+
+$template = str_replace('{{ coverage }}', $coverageName, $template);
+
+$color = '#a4a61d';      // Default Gray
+if ($totalCoverage < 40) {
+    $color = '#e05d44';  // Red
+} elseif($totalCoverage < 60) {
+    $color = '#fe7d37';  // Orange
+} elseif($totalCoverage < 75) {
+    $color = '#dfb317';  // Yellow
+} elseif($totalCoverage < 90) {
+    $color = '#a4a61d';  // Yellow-Green
+} elseif($totalCoverage < 95) {
+    $color = '#97CA00';  // Green
+} elseif ($totalCoverage <= 100) {
+    $color = '#4c1';     // Bright Green
+}
+
+$template = str_replace('{{ total }}', $totalCoverage, $template);
+$template = str_replace('{{ color }}', $color, $template);
+
+file_put_contents($outputFile, $template);


### PR DESCRIPTION
The script coverage-badge.php has been updated to handle multiple input files. Instead of accepting a single file, it now takes in a comma-separated list of files and computes the average coverage. The README.md file has also been updated to include more specific installation instructions.