### PR TITLE
Add PHPStan and modify error handling in BadgeComposer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
     "homepage": "https://github.com/codebtech/coveragebadge",
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-deprecation-rules": "^1.2",
+        "phpstan/phpstan-strict-rules": "^1.6",
         "phpunit/phpunit": "^11.1",
         "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.10"
@@ -42,6 +45,7 @@
         "lint": "phpcs",
         "lint:fix": "phpcbf",
         "php:badge": "bin/coverage-badge coverage/clover.xml badges/php.svg PHP",
+        "phpstan": "phpstan analyse --memory-limit=2048M",
         "test": "phpunit --testdox --coverage-clover coverage/clover.xml --coverage-html coverage --coverage-filter src/"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cbcf0d2464229eca9963d6930abbe380",
+    "content-hash": "9c42876b22feb92f2125ade2b6f81639",
     "packages": [],
     "packages-dev": [
         {
@@ -905,6 +905,160 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
             },
             "time": "2024-05-31T08:52:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "e64220a05c1209fc856d58e789c3b7a32c0bb9a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e64220a05c1209fc856d58e789c3b7a32c0bb9a5",
+                "reference": "e64220a05c1209fc856d58e789c3b7a32c0bb9a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-05-31T13:53:37+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.11"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.0"
+            },
+            "time": "2024-04-20T06:39:48+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "363f921dd8441777d4fc137deb99beb486c77df1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/363f921dd8441777d4fc137deb99beb486c77df1",
+                "reference": "363f921dd8441777d4fc137deb99beb486c77df1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.11"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.6.0"
+            },
+            "time": "2024-04-20T06:37:51+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    level: max
+    paths:
+        - coverage-badge.php
+        - src/
+    excludePaths:
+        - tests/*

--- a/src/BadgeComposer.php
+++ b/src/BadgeComposer.php
@@ -22,9 +22,13 @@ use function str_replace;
  */
 class BadgeComposer
 {
+    /**
+     * @var string[]
+     */
     private array $inputFiles;
     private string $outputFile;
     private string $coverageName;
+    private string $badgeTemplate = __DIR__ . '/../template/badge.svg';
     private int $totalCoverage = 0;
     private int $totalElements = 0;
     private int $checkedElements = 0;
@@ -56,7 +60,7 @@ class BadgeComposer
      *
      * This method checks if the input files exist and if the output file is provided.
      *
-     * @param array $inputFiles The array of input files to validate.
+     * @param string[] $inputFiles The array of input files to validate.
      * @param string $outputFile The output file to validate.
      *
      * @throws Exception If any of the input files do not exist or if the output file is not provided.
@@ -128,7 +132,11 @@ class BadgeComposer
     private function finalizeCoverage(): void
     {
         $totalCoverage = $this->totalCoverage / count($this->inputFiles); // Average coverage across all files
-        $template = file_get_contents(__DIR__ . '/../template/badge.svg');
+        $template = file_get_contents($this->badgeTemplate);
+
+        if($template === false) {
+            throw new Exception('Error reading badge template file');
+        }
 
         $template = str_replace('{{ total }}', (string) $totalCoverage, $template);
 

--- a/tests/BadgeComposerTest.php
+++ b/tests/BadgeComposerTest.php
@@ -110,13 +110,14 @@ class BadgeComposerTest extends TestCase
     }
 
     /**
+     * @param bool $manipulate
      * @throws ReflectionException
      */
-    public function finalizeCoverage($manipuate = false)
+    public function finalizeCoverage($manipulate = false)
     {
         $method = (new ReflectionClass($this->badgeComposer))->getMethod('finalizeCoverage');
 
-        if($manipuate) {
+        if($manipulate) {
             $property = (new ReflectionClass($this->badgeComposer))->getProperty('badgeTemplate');
             $property->setValue($this->badgeComposer, 'invalid.svg');
         }
@@ -142,7 +143,7 @@ class BadgeComposerTest extends TestCase
      */
     public function testFinalizeCoverageFailsWhenBadgeTemplateFileIsMissing(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(Throwable::class);
         $this->expectExceptionMessage('Error reading badge template file');
 
         $this->finalizeCoverage(true);

--- a/tests/BadgeComposerTest.php
+++ b/tests/BadgeComposerTest.php
@@ -112,9 +112,14 @@ class BadgeComposerTest extends TestCase
     /**
      * @throws ReflectionException
      */
-    public function finalizeCoverage()
+    public function finalizeCoverage($manipuate = false)
     {
         $method = (new ReflectionClass($this->badgeComposer))->getMethod('finalizeCoverage');
+
+        if($manipuate) {
+            $property = (new ReflectionClass($this->badgeComposer))->getProperty('badgeTemplate');
+            $property->setValue($this->badgeComposer, 'invalid.svg');
+        }
 
         return $method->invoke($this->badgeComposer);
     }
@@ -130,6 +135,17 @@ class BadgeComposerTest extends TestCase
         $this->assertStringContainsString('#e05d44', $outputFileContent);
 
         $this->assertStringContainsString('unit', $outputFileContent);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testFinalizeCoverageFailsWhenBadgeTemplateFileIsMissing(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Error reading badge template file');
+
+        $this->finalizeCoverage(true);
     }
 
 }


### PR DESCRIPTION
This commit adds PHPStan and its related strict rules and deprecation rules to the `composer.json`. It also modifies the `finalizeCoverage` method in `BadgeComposer` to handle errors when badge template file is missing. A test for this scenario has been added to `BadgeComposerTest.php`.