### PR TITLE
Fix code coverage calculation to match coverage generated by `esi/phpunit-coverage-check`

### DIFF
--- a/src/BadgeComposer.php
+++ b/src/BadgeComposer.php
@@ -112,22 +112,26 @@ class BadgeComposer
                 throw new Exception('Error reading file: ' . $inputFile);
             }
             $xml = new SimpleXMLElement($content);
-            $metrics = $xml->xpath('//metrics');
+            $metrics = $xml->xpath('//project/metrics');
 
             $totalConditionals = 0;
             $totalStatements = 0;
             $coveredStatements = 0;
             $coveredConditionals = 0;
+            $methods = 0;
+            $coveredMethods = 0;
 
             foreach ($metrics as $metric) {
                 $totalConditionals   += (int) $metric['conditionals'];
                 $coveredConditionals += (int) $metric['coveredconditionals'];
-                $totalStatements    += (int) $metric['statements'];
-                $coveredStatements  += (int) $metric['coveredstatements'];
+                $totalStatements     += (int) $metric['statements'];
+                $coveredStatements   += (int) $metric['coveredstatements'];
+                $methods             += (int) $metric['methods'];
+                $coveredMethods      += (int) $metric['coveredmethods'];
             }
 
-            $totalElements = $totalConditionals + $totalStatements;
-            $coveredElements = $coveredConditionals + $coveredStatements;
+            $totalElements = $totalConditionals + $methods + $totalStatements;
+            $coveredElements = $coveredConditionals + $coveredMethods + $coveredStatements;
             $coverageRatio = $totalElements ? $coveredElements / $totalElements : 0;
             $this->totalCoverage[] = (int) round($coverageRatio * 100);
 


### PR DESCRIPTION
I've noticed that generated coverage on badges doesn't match the coverage generated by [esi/phpunit-coverage-check](https://github.com/ericsizemore/phpunit-coverage-check) package, which is commonly used.

This PR adjusts the calculation to match the one generated by other libraries.

